### PR TITLE
Gen-Lambda Matching

### DIFF
--- a/LambaAnalyzer/src/LambdaAnalyzer.cc
+++ b/LambaAnalyzer/src/LambdaAnalyzer.cc
@@ -678,42 +678,6 @@ void LambdaAnalyzer::loop(const edm::Event& iEvent, const edm::EventSetup& iSetu
         double z_p = ip4_Lambda.Z();
         double scale_ca = (x_p*PVx + y_p*PVy + z_p*PVz )/(x_p*x_p + y_p*y_p + z_p*z_p);
 
-        /*
-        //look for matching TrackingParticles
-        double min_pion_dR = 99.;
-        double min_p_dR = 99.;
-        double pion_dR = 99.;
-        double p_dR = 99.;
-        int pionIndex=-1;
-        int pIndex=-1;
-        int lambdaIndex = -1;
-        for(TrackingParticleCollection::const_iterator iter = tPC->begin(); iter != tPC->end(); ++iter){
-           pion_dR = deltaR(ip4_pi1.Eta(),ip4_pi1.Phi(),iter->eta(),iter->phi());  
-           p_dR = deltaR(ip4_proton.Eta(),ip4_proton.Phi(),iter->eta(),iter->phi());   
-           int pID = iter->pdgId();
-           TrackingVertexRef sourceVtxRef = iter->parentVertex();
-           //look for pion
-           if(pion_dR<min_pion_dR && (pID==-211)){
-              //lambda should be only sourceTrack, but loop through to be safe
-              for(TrackingParticleRefVector::iterator sourceIter = sourceVtxRef->sourceTracks_begin(); sourceIter != sourceVtxRef->sourceTracks_end(); ++sourceIter){
-                 if((*sourceIter)->pdgId()==3122){
-                    lambdaIndex = std::distance(sourceVtxRef->sourceTracks_begin(), sourceIter);
-                    min_pion_dR = pion_dR;
-                    pionIndex = std::distance(tPC->begin(), iter);
-                 }
-              }
-           }//look for proton
-           else if(p_dR<min_p_dR && (pID==2212)){ 
-              for(TrackingParticleRefVector::iterator sourceIter = sourceVtxRef->sourceTracks_begin(); sourceIter != sourceVtxRef->sourceTracks_end(); ++sourceIter){
-                 if((*sourceIter)->pdgId()==3122){
-                    min_p_dR = p_dR;
-                    pIndex = std::distance(tPC->begin(), iter);
-                 }
-              }
-        
-           }
-        }*/
-      
         //Iterate over lambdas to find the best match to pion/proton tracks
         double min_dR = 99;
         double pion_dR = 99;
@@ -728,12 +692,11 @@ void LambdaAnalyzer::loop(const edm::Event& iEvent, const edm::EventSetup& iSetu
         for(TrackingParticleCollection::const_iterator iter = tPC->begin(); iter != tPC->end(); ++iter){
            //is lambda?
            if(iter->pdgId()==3122){
-              TrackingVertexRef decayVtx = *(iter->decayVertices().end()-1);//some lambdas have multiple decay vertices, just look at the last one for pion/proton
+              TrackingVertexRef decayVtx = *(iter->decayVertices().end()-1);//some lambdas have multiple decay vertices, looking at just the last one seems to work
               decayTracks = decayVtx->daughterTracks();
               
               //check lambda decays to p,pi?
               if(decayTracks.size() >= 2){
-                 //std::cout << "pdgIDs: " << decayTracks.at(0)->pdgId() << " " << decayTracks.at(1)->pdgId() << std::endl;
                  if(decayTracks.at(0)->pdgId()==-211 && decayTracks.at(1)->pdgId()==2212){
                     genPion = decayTracks.at(0);
                     genProton = decayTracks.at(1);
@@ -754,21 +717,6 @@ void LambdaAnalyzer::loop(const edm::Event& iEvent, const edm::EventSetup& iSetu
               }
            }
         }
-        std::cout <<"min_dR " <<  min_dR << std::endl;
-        //TrackingVertexRef genLambdaVtx = *(genLambda.decayVertices().end()-1);
-        //TrackingVertexRef LambdaDecayVtx = 
-        //if(min_dR<0.2) std::cout <<"Good Lambda!" << std::endl;
-
-        //TrackingVertexRef pionSourceVtxRef = tPC->at(pionIndex).parentVertex();
-        //TrackingVertexRef pSourceVtxRef = tPC->at(pIndex).parentVertex();
-        //TrackingParticleRef lambdaRef = pionSourceVtxRef->sourceTracks().at(lambdaIndex);
-        //dR cut
-        //if(min_pion_dR > .1 || min_p_dR > .1) continue;
-        //make sure pion and p come from same vertex
-        //bool foundMatch=false;
-        //if(pionSourceVtxRef==pSourceVtxRef) foundMatch=true;
-        //if(foundMatch) std::cout << "found lambda (original)" <<std::endl; 
-        //if(sqrt(pow(pSourceVtxRef->position().x() - pionSourceVtxRef->position().x(),2) +  pow(pSourceVtxRef->position().y() - pionSourceVtxRef->position().y(),2) + pow(pSourceVtxRef->position().z() - pionSourceVtxRef->position().z(),2)) < .000001){
          
         LambdaVtxProb.push_back(vtxProb);
         LambdaVtxLSig.push_back(LSig);

--- a/LambaAnalyzer/test/trkeffanalyzer_MC_GeneralTracks_cfg.py
+++ b/LambaAnalyzer/test/trkeffanalyzer_MC_GeneralTracks_cfg.py
@@ -32,14 +32,19 @@ process.GlobalTag.globaltag = '101X_upgrade2018_realistic_v7'
 
 #filelist = FileUtils.loadListFromFile("inputlist.list")
 #filelist = FileUtils.loadListFromFile("onefile.list")
+process.maxEvents = cms.untracked.PSet( 
+    input = cms.untracked.int32(-1)
+)
 
-process.source = cms.Source('PoolSource',
-#fileNames = cms.untracked.vstring(*filelist),
-fileNames = cms.untracked.vstring(#'/store/data/Run2018C/ZeroBias/RAW-RECO/LogError-PromptReco-v1/000/319/347/00000/86EFC8CD-DE84-E811-8983-FA163EC985ED.root'
-#'/store/data/Run2018C/ZeroBias/RAW-RECO/LogError-PromptReco-v1/000/319/347/00000/86EFC8CD-DE84-E811-8983-FA163EC985ED.root'
-#'/store/mc/RunIIAutumn18DRPremix/QCD_Pt-15to7000_TuneCP5_Flat2018_13TeV_pythia8/GEN-SIM-RECO/102X_upgrade2018_realistic_v15_ext1-v2/60000/7E8A8DF4-FBBE-EF4F-97DB-0B1C8EE1A059.root'
-'/store/mc/RunIIAutumn18DRPremix/SingleNeutrino/GEN-SIM-RECO/forRECO_102X_upgrade2018_realistic_v15_ext1-v1/100000/18847E99-339C-634B-8F2B-C5CB4E0869CE.root'
-),
+process.source = cms.Source("PoolSource",
+                #GEN-SIM-RECO file
+                fileNames=cms.untracked.vstring(
+                '/store/relval/CMSSW_10_2_3/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-RECO/PU25ns_102X_upgrade2018_realistic_v11-v1/20000/FAC4072D-E9C0-7D47-B58C-7C9C8580E39A.root', 
+                ),
+                #GEN-SIM-DIGI-RAW parent file
+                secondaryFileNames=cms.untracked.vstring(
+                '/store/relval/CMSSW_10_2_3/RelValQCD_FlatPt_15_3000HS_13/GEN-SIM-DIGI-RAW/PU25ns_102X_upgrade2018_realistic_v11-v1/20000/E25311AE-F39E-924D-AAF9-623DDBBE1B8C.root ',
+                ),   
 #skipEvents = cms.untracked.uint32(100000)
 inputCommands=cms.untracked.vstring(
                   'keep *',
@@ -160,6 +165,8 @@ process.analyzer = cms.EDAnalyzer('LambdaAnalyzer',
     vertices = cms.untracked.InputTag("offlinePrimaryVertices"),
     genParticles = cms.untracked.InputTag("genParticles"),
     T2V = cms.untracked.InputTag("Tracks2Vertex"),
+    trackingParticles = cms.InputTag("mix","MergedTrackTruth"),
+    trackingVertices = cms.InputTag("mix","MergedTrackTruth"),
 )
 
 process.TFileService = cms.Service("TFileService",


### PR DESCRIPTION
This PR adds gen-lambda matching to the MC analyzer.  Gen lambdas from the TrackingParticles collection are matched to reco lambdas by picking the lambda whose decay products minimize DeltaR(pion, reco pion track) + DeltaR(proton, reco proton track).  The TrackingParticles collection can be found in GEN-SIM-DIGI-RAW files, which must be the parents of the GEN-SIM-RECO files being processed.